### PR TITLE
Categorize Fugro branding colors; add short line segment to image

### DIFF
--- a/DotNet/RoadmapLogic/FugroColors.cs
+++ b/DotNet/RoadmapLogic/FugroColors.cs
@@ -1,0 +1,20 @@
+﻿using SixLabors.ImageSharp;
+
+namespace RoadmapLogic
+{
+    public static class FugroColors
+    {
+        public static Color QuantumBlue = Color.FromRgb(1, 30, 65);
+        public static Color GravityGrey = Color.FromRgb(217, 216, 214);
+
+        /// <summary>
+        /// TODO: This is like a lighter version of QuantumBlue. Can't find it in branding docs.
+        /// </summary>
+        public static Color WhatColorIsThisBlue = Color.FromRgb(47, 68, 93);
+
+        public static Color PulseBlue = Color.FromRgb(103, 136, 177);
+        public static Color StrataTurquoise = Color.FromRgb(71, 156, 170);
+        public static Color CosmicSand = Color.FromRgb(217, 190, 137);
+        public static Color MotionGreen = Color.FromRgb(140, 182, 128);
+    }
+}

--- a/DotNet/RoadmapLogic/RoadmapImage.cs
+++ b/DotNet/RoadmapLogic/RoadmapImage.cs
@@ -33,7 +33,10 @@ namespace RoadmapLogic
 
             using (var image = new Image<Rgba32>(1486, 839))
             {
-                image.Mutate(x => x.DrawText("Product delivery roadmap", headerFont, Color.Black, new PointF(100, 59) ));
+                // Draw short line just above image title
+                image.Mutate(x => x.DrawLines(FugroColors.QuantumBlue, 3.3f, new PointF(85, 45), new PointF(185, 45)));
+
+                image.Mutate(x => x.DrawText("Product delivery roadmap", headerFont, FugroColors.QuantumBlue, new PointF(100, 59) ));
 
                 image.Mutate(x => x.DrawText(teamText, teamFont, Color.Black, new PointF(100, 184)));
 
@@ -44,10 +47,10 @@ namespace RoadmapLogic
                 int chevronHeight = 50;
                 IPath chevronPath;
                 Color[] chevronColors = {
-                    Color.FromRgb(47, 68, 93),
-                    Color.FromRgb(71, 156, 170),
-                    Color.FromRgb(140, 182, 128),
-                    Color.FromRgb(217, 190, 137)
+                    FugroColors.WhatColorIsThisBlue,
+                    FugroColors.StrataTurquoise,
+                    FugroColors.MotionGreen,
+                    FugroColors.CosmicSand
                 };
 
                 for (int i = 0; i < 4; i++)


### PR DESCRIPTION
This captures the Fugro-specific colors in a static class and adds a short line segment above the roadmap title.

One of the blue colors doesn't match up with official Fugro branding.