### PR TITLE
Optional 'quarters' input draws between 1 and 4 quarter chevrons

### DIFF
--- a/DotNet/RoadmapLambda/FunctionInput.cs
+++ b/DotNet/RoadmapLambda/FunctionInput.cs
@@ -14,6 +14,8 @@ namespace RoadmapLambda
         [JsonPropertyName("start_date")]
         public string StartDate { get; set; }
 
+        public int? Quarters { get; set; }
+
         public IEnumerable<FunctionProject> Projects { get; set; }
 
         /// <summary>
@@ -21,7 +23,7 @@ namespace RoadmapLambda
         /// </summary>
         public RoadmapLogic.Input ToRoadmapInput()
         {
-            return new RoadmapLogic.Input(Team, StartDate, Projects.Select(p => p.ToRoadmapProject()));
+            return new RoadmapLogic.Input(Team, StartDate, Projects.Select(p => p.ToRoadmapProject()), Quarters);
         }
     }
 

--- a/DotNet/RoadmapLambda/aws-lambda-tools-defaults.json
+++ b/DotNet/RoadmapLambda/aws-lambda-tools-defaults.json
@@ -11,7 +11,7 @@
     "configuration" : "Debug",
     "framework"     : "netcoreapp3.1",
     "function-runtime" : "dotnetcore3.1",
-    "function-memory-size" : 128,
+    "function-memory-size" : 1024,
     "function-timeout"     : 30,
     "function-handler"     : "RoadmapLambda::RoadmapLambda.Function::FunctionHandler",
     "function-name"        : "rdamt-roadmap-generator-test",

--- a/DotNet/RoadmapLogic.Tests/CalculationsTest.cs
+++ b/DotNet/RoadmapLogic.Tests/CalculationsTest.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Collections.Generic;
 
 namespace RoadmapLogic.Tests
 {
@@ -10,7 +9,7 @@ namespace RoadmapLogic.Tests
         [TestMethod]
         public void GetQuartersTest()
         {
-            List<Quarter> quarters = Quarter.GetQuarters(new DateTime(2020, 7, 15));
+            var quarters = Quarter.GetQuarters(new DateTime(2020, 7, 15));
             
             Assert.AreEqual(2020, quarters[0].Year);
             Assert.AreEqual(3, quarters[0].Index);
@@ -41,7 +40,7 @@ namespace RoadmapLogic.Tests
                                             16, 38, "Product delivery roadmap", 57, 100, DefaultColors.QuantumBlue,
                                             string.Empty, string.Empty, string.Empty);
 
-            List<Quarter> quarters = Quarter.GetQuarters(new DateTime(2020, 3, 1));
+            var quarters = Quarter.GetQuarters(new DateTime(2020, 3, 1));
 
             Assert.AreEqual(366, Calculations.JulianDayToPixel(settings, quarters).Values.Count);
             

--- a/DotNet/RoadmapLogic.Tests/ImageTest.cs
+++ b/DotNet/RoadmapLogic.Tests/ImageTest.cs
@@ -21,13 +21,11 @@ namespace RoadmapLogic.Tests
                 new Project("Task 5 - Description", "Status", "6/21/2021")
             };
 
-            Input input = new Input("Enter TeamName Here:", "12/15/2020", Projects);
+            Input input = new Input("Enter TeamName Here:", "12/15/2020", Projects, 4);
 
             var imageStream = RoadmapImage.MakeImage(input, Settings.Default);
-
             var bytes = imageStream.ToArray();
-
-            File.WriteAllBytes($"test-{DateTime.Now:yyyy-MM-dd-hh-mm-ss-fff}.png", bytes);
+            WriteBytesToTimestampedFile("test", bytes);
         }
 
         [TestMethod]
@@ -40,13 +38,11 @@ namespace RoadmapLogic.Tests
                 new Project(string.Empty, string.Empty, "4/26/2021"),
             };
 
-            Input input = new Input("Enter TeamName Here:", "12/15/2020", Projects);
+            Input input = new Input("Enter TeamName Here:", "12/15/2020", Projects, 4);
 
             var imageStream = RoadmapImage.MakeImage(input, Settings.Default);
-
             var bytes = imageStream.ToArray();
-
-            File.WriteAllBytes($"missingNameAndValue-{DateTime.Now:yyyy-MM-dd-hh-mm-ss-fff}.png", bytes);
+            WriteBytesToTimestampedFile("test-missingNameAndValue", bytes);
         }
 
         [TestMethod]
@@ -62,13 +58,11 @@ namespace RoadmapLogic.Tests
                 new Project(string.Empty, "Status", string.Empty)
             };
 
-            Input input = new Input("Enter TeamName Here:", "12/15/2020", Projects);
+            Input input = new Input("Enter TeamName Here:", "12/15/2020", Projects, 4);
 
             var imageStream = RoadmapImage.MakeImage(input, Settings.Default);
-
             var bytes = imageStream.ToArray();
-
-            File.WriteAllBytes($"missingDate-{DateTime.Now:yyyy-MM-dd-hh-mm-ss-fff}.png", bytes);
+            WriteBytesToTimestampedFile("test-missingDate", bytes);
         }
 
         [TestMethod]
@@ -115,13 +109,11 @@ namespace RoadmapLogic.Tests
                 new Project("Task 37, This is the", "description that will", "12/31/2021"),
             };
 
-            Input input = new Input("Truncated Placard Test:", "01/01/2021", Projects);
+            Input input = new Input("Truncated Placard Test:", "01/01/2021", Projects, 4);
 
-            var imageStream = RoadmapImage.MakeImage(input, Settings.Default);
-            
+            var imageStream = RoadmapImage.MakeImage(input, Settings.Default);            
             var bytes = imageStream.ToArray();
-
-            File.WriteAllBytes($"truncated-{DateTime.Now:yyyy-MM-dd-hh-mm-ss-fff}.png", bytes);
+            WriteBytesToTimestampedFile("test-truncated", bytes);
         }
 
         [TestMethod]
@@ -138,6 +130,11 @@ namespace RoadmapLogic.Tests
             var saveTo = Path.Combine(pathUpToFilename, txtFile);
 
             File.WriteAllText(saveTo, new Base64Converter().ToBase64(imageFile));
+        }
+
+        private void WriteBytesToTimestampedFile(string filenamePart, byte[] bytes)
+        {
+            File.WriteAllBytes($"{filenamePart }-{DateTime.Now:yyyy-MM-dd-hh-mm-ss-fff}.png", bytes);
         }
     }
 }

--- a/DotNet/RoadmapLogic.Tests/QuarterTests.cs
+++ b/DotNet/RoadmapLogic.Tests/QuarterTests.cs
@@ -1,0 +1,67 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
+
+namespace RoadmapLogic.Tests
+{
+    [TestClass]
+    public class QuarterTests
+    {
+        [TestMethod]
+        public void CreatesFourQuartersByDefault()
+        {
+            var startTime = new DateTime(2021, 1, 1);
+            var result = Quarter.GetQuarters(startTime);
+
+            Assert.AreEqual(4, result.Count());
+            Assert.AreEqual(new Quarter(2021, 1), result[0]);
+            Assert.AreEqual(new Quarter(2021, 2), result[1]);
+            Assert.AreEqual(new Quarter(2021, 3), result[2]);
+            Assert.AreEqual(new Quarter(2021, 4), result[3]);
+        }
+
+        [TestMethod]
+        public void CreatesTwoQuarters()
+        {
+            var startTime = new DateTime(2021, 1, 1);
+            var result = Quarter.GetQuarters(startTime, 2);
+
+            Assert.AreEqual(2, result.Count());
+            Assert.AreEqual(new Quarter(2021, 1), result[0]);
+            Assert.AreEqual(new Quarter(2021, 2), result[1]);
+        }
+
+        [TestMethod]
+        public void CreatesThreeQuartersBeginningInQ4()
+        {
+            var startTime = new DateTime(2021, 10, 1);
+            var result = Quarter.GetQuarters(startTime, 3);
+
+            Assert.AreEqual(3, result.Count());
+            Assert.AreEqual(new Quarter(2021, 4), result[0]);
+            Assert.AreEqual(new Quarter(2022, 1), result[1]);
+            Assert.AreEqual(new Quarter(2022, 2), result[2]);
+        }
+        
+        [DataTestMethod]
+        [DataRow(-1)]
+        [DataRow(5)]
+        public void CreatesFourQuartersGivenBadQuarterInput(int quarters)
+        {
+            var startTime = new DateTime(2021, 10, 1);
+            var result = Quarter.GetQuarters(startTime, quarters);
+
+            Assert.AreEqual(4, result.Count());
+        }
+
+
+        [TestMethod]
+        public void JulianDayRangeForQ1()
+        {
+            var julianDays = new Quarter(2021, 1).GetJulianDayRange();
+
+            Assert.AreEqual(1, julianDays.Item1);
+            Assert.AreEqual(31 + 28 + 31, julianDays.Item2);
+        }
+    }
+}

--- a/DotNet/RoadmapLogic/Calculations.cs
+++ b/DotNet/RoadmapLogic/Calculations.cs
@@ -10,7 +10,7 @@ namespace RoadmapLogic
             return (int)(date - new DateTime(date.Year, 1, 1)).TotalDays + 1;
         }
 
-        public static Dictionary<int, float> JulianDayToPixel(Settings settings, List<Quarter> quarters)
+        public static Dictionary<int, float> JulianDayToPixel(Settings settings, IEnumerable<Quarter> quarters)
         {
             float chevronXStart = settings.Margin.Left;
             var dict = new Dictionary<int, float>();
@@ -18,7 +18,7 @@ namespace RoadmapLogic
 
             foreach (var quarter in quarters)
             {
-                var quarterData = QuarterData(quarter);
+                var quarterData = quarter.GetJulianDayRange();
                 var start = quarterData.Item1;
                 float pixelInterval = settings.ChevronLength / (quarterData.Item2 - 1);
                 for (int i = 0; i < quarterData.Item2; i++)
@@ -41,31 +41,6 @@ namespace RoadmapLogic
         {
             // Scale to position 0.169230769            
             return (fontSize - 5) * -0.169230769F;
-        }
-
-        private static Tuple<int, int> QuarterData(Quarter quarter)
-        {
-            var result = new Tuple<int, int>(-1, -1);
-            switch (quarter.Index)
-            {
-                case 1:
-                    result = new Tuple<int, int>(GetJulianDay(new DateTime(quarter.Year,1,1)), 
-                        GetJulianDay(new DateTime(quarter.Year, 3, 31)));
-                    break;
-                case 2:
-                    result = new Tuple<int, int>(GetJulianDay(new DateTime(quarter.Year, 4, 1)), 
-                        GetJulianDay(new DateTime(quarter.Year, 6, 30)) - GetJulianDay(new DateTime(quarter.Year, 3, 31)));
-                    break;
-                case 3:
-                    result = new Tuple<int, int>(GetJulianDay(new DateTime(quarter.Year, 7, 1)), 
-                        GetJulianDay(new DateTime(quarter.Year, 9, 30)) - GetJulianDay(new DateTime(quarter.Year, 6, 30)));
-                    break;
-                case 4:
-                    result = new Tuple<int, int>(GetJulianDay(new DateTime(quarter.Year, 10, 1)), 
-                        GetJulianDay(new DateTime(quarter.Year, 12, 31)) - GetJulianDay(new DateTime(quarter.Year, 9, 30)));
-                    break;
-            }
-            return result;
         }
     }
 }

--- a/DotNet/RoadmapLogic/Input.cs
+++ b/DotNet/RoadmapLogic/Input.cs
@@ -6,13 +6,18 @@ namespace RoadmapLogic
 {
     public class Input
     {
-        public Input(string team, string startDate, IEnumerable<Project> projects)
+        public Input(
+            string team,
+            string startDate,
+            IEnumerable<Project> projects,
+            int? numberOfQuarters = 4)
         {
             Team = team;
             if (IsValid = DateConverter.ConvertToDate(startDate, out DateTime date))
             {
                 StartDate = date;
                 Projects = projects;
+                Quarters = numberOfQuarters;
 
                 if (projects.Any(p => !p.IsValid))
                 {
@@ -32,5 +37,7 @@ namespace RoadmapLogic
         public DateTime StartDate { get; }
 
         public IEnumerable<Project> Projects { get; }
+
+        public int? Quarters { get; }
     }
 }

--- a/DotNet/RoadmapLogic/RoadmapImage.cs
+++ b/DotNet/RoadmapLogic/RoadmapImage.cs
@@ -3,6 +3,7 @@ using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace RoadmapLogic
 {
@@ -33,7 +34,7 @@ namespace RoadmapLogic
                         Color.Black,
                         new PointF(settings.Margin.Right, settings.MidPoint - settings.PlotHeight - settings.TeamFontSize - 10));
 
-                    List<Quarter> quarters = Quarter.GetQuarters(input.StartDate);
+                    var quarters = Quarter.GetQuarters(input.StartDate, input.Quarters);
 
                     DrawLegsAndPlacards(input, settings, fonts, image, quarters);
 
@@ -70,14 +71,14 @@ namespace RoadmapLogic
             }
         }
 
-        private static void DrawLegsAndPlacards(Input input, Settings settings, Fonts fonts, Image<Rgba32> image, List<Quarter> quarters)
+        private static void DrawLegsAndPlacards(Input input, Settings settings, Fonts fonts, Image<Rgba32> image, IEnumerable<Quarter> quarters)
         {
             const string missingProjectMessageText = "Alert! Project(s) have been omitted from the roadmap. Please Review.";
             RendererOptions renderOptions = new RendererOptions(fonts.PlacardFont);
             bool hasMissingProjects = false;
             
             var positions = Calculations.JulianDayToPixel(settings, quarters);
-            var projects = Project.SortProjects(input.Projects, quarters[0]);
+            var projects = Project.SortProjects(input.Projects, quarters.First());
             Position position = Position.Top;
             int index = 0;
             var placardEndPixel = new float[,]

--- a/Web/js/ui.js
+++ b/Web/js/ui.js
@@ -3,6 +3,7 @@ const useSample = () => {
     const sample = {
         'team': 'Your Team',
         'start_date': '01/01/' + thisYear.toString(),
+        'quarters': 4,
         'projects': [
             {
                 'name': 'Build Product',


### PR DESCRIPTION
Input now supports optional "quarters" integer. Min value = 1, Max value = 4. If arg is not specified, or is not within min-max range, it is changed to 4. Added unit tests.

Also moved a very-Quarter-specific method out of Calculations and into Quarter class.