### PR TITLE
RDAMR-244: Scaled image contents to fit all projects for a quarter

### DIFF
--- a/DotNet/RoadmapLogic.Tests/CalculationsTest.cs
+++ b/DotNet/RoadmapLogic.Tests/CalculationsTest.cs
@@ -37,7 +37,7 @@ namespace RoadmapLogic.Tests
         {
             Settings settings = new Settings(378, 366, new Margin(0, 0), 485, 50, 23, 4, 50, 32,
                                             new int[] { 217, 141, 65 }, new int[] { 176, 100, 24 }, 10, 20,
-                                            16, 38, "Product delivery roadmap", 57, 100, DefaultColors.QuantumBlue,
+                                            12, 38, "Product delivery roadmap", 57, 100, DefaultColors.QuantumBlue,
                                             string.Empty, string.Empty, string.Empty);
 
             var quarters = Quarter.GetQuarters(new DateTime(2020, 3, 1));

--- a/DotNet/RoadmapLogic.Tests/ImageTest.cs
+++ b/DotNet/RoadmapLogic.Tests/ImageTest.cs
@@ -9,6 +9,22 @@ namespace RoadmapLogic.Tests
     public class ImageTest
     {
         [TestMethod]
+        public void CreateAndSaveDefaultImage()
+        {
+            var Projects = new List<Project>
+            {
+                new Project("Build Product", "Ongoing", "01/01/2021"),
+                new Project("Test Product", "Not Started", "06/01/2021")
+            };
+
+            Input input = new Input("Your Team:", "01/01/2021", Projects, 4);
+
+            var imageStream = RoadmapImage.MakeImage(input, Settings.Default);
+            var bytes = imageStream.ToArray();
+            WriteBytesToTimestampedFile("default", bytes);
+        }
+
+        [TestMethod]
         public void CreateAndSaveImage()
         {
             var Projects = new List<Project>
@@ -172,7 +188,7 @@ namespace RoadmapLogic.Tests
         {
             var Projects = new List<Project>
             {
-                new Project("Task 1, This description should be too tion should be to", "Status", "1/1/2021"),
+                new Project("Task 1, This description should be too long to be viewed", "Status", "1/1/2021"),
                 new Project("Task 2", "Status", "1/10/2021"),
                 new Project("Task 3", "Status", "1/20/2021"),
                 new Project("Task 4", "Status", "2/1/2021"),
@@ -206,7 +222,7 @@ namespace RoadmapLogic.Tests
                 new Project("Task 32", "Status", "11/10/2021"),
                 new Project("Task 33", "Status", "11/20/2021"),
                 new Project("Task 34", "Status", "12/1/2021"),
-                new Project("Task 35, This description should be too tion should be to", "Status", "12/10/2021"),
+                new Project("Task 35, This description should be too long to be viewed", "Status", "12/10/2021"),
                 new Project("Task 36", "Status", "12/20/2021"),
                 new Project("Task 37, This is the", "description that will", "12/31/2021"),
             };
@@ -223,39 +239,39 @@ namespace RoadmapLogic.Tests
         {
             var Projects = new List<Project>
             {
-                new Project("Task 1, This description should be too tion should be to", "Status", "1/1/2021"),
+                new Project("Task 1, This description should be too long to be viewed", "Status", "1/1/2021"),
                 new Project("Task 2, This is a little long", "The status is unknown", "1/10/2021"),
                 new Project("Task 3, This is a little long", "Status", "1/20/2021"),
                 new Project("Task 4, This desciption is a medium long", "The status is unknown", "2/1/2021"),
-                new Project("Task 5, This description should be too tion should be to", "Status", "2/10/2021"),
+                new Project("Task 5, This description should be too long to be viewed", "Status", "2/10/2021"),
                 new Project("Task 6, This desciption is a medium long", "Status", "2/20/2021"),
                 new Project("Task 7, This is a little long", "The status is unknown", "3/1/2021"),
-                new Project("Task 8, This description should be too tion should be to", "Status", "3/10/2021"),
+                new Project("Task 8, This description should be too long to be viewed", "Status", "3/10/2021"),
                 new Project("Task 9, This desciption is a medium long", "Status", "3/20/2021"),
                 new Project("Task 11, This is a little long, ", "Status", "4/10/2021"),
                 new Project("Task 12, This desciption is a medium long", "The status is unknown", "4/20/2021"),
-                new Project("Task 13, This description should be too tion should be to", "Status", "5/1/2021"),
+                new Project("Task 13, This description should be too long to be viewed", "Status", "5/1/2021"),
                 new Project("Task 14, This desciption is a medium long", "The status is unknown", "5/10/2021"),
                 new Project("Task 15, This is a little long", "Status", "5/20/2021"),
                 new Project("Task 16, This desciption is a medium long", "Status", "6/1/2021"),
                 new Project("Task 17, This desciption is a medium long", "The status is unknown", "6/10/2021"),
                 new Project("Task 18, This is a little long", "The status is unknown", "6/20/2021"),
-                new Project("Task 19, This description should be too tion should be to", "Status", "7/1/2021"),
+                new Project("Task 19, This description should be too long to be viewed", "Status", "7/1/2021"),
                 new Project("Task 20, This is a little long", "The status is unknown", "7/10/2021"),
-                new Project("Task 21, This description should be too tion should be to", "Status", "7/20/2021"),
+                new Project("Task 21, This description should be too long to be viewed", "Status", "7/20/2021"),
                 new Project("Task 22, This desciption is a medium long", "Status", "8/1/2021"),
-                new Project("Task 23, This description should be too tion should be to", "Status", "8/10/2021"),
+                new Project("Task 23, This description should be too long to be viewed", "Status", "8/10/2021"),
                 new Project("Task 24, This is a little long", "Status", "8/20/2021"),
                 new Project("Task 25, This desciption is a medium long", "Status", "9/1/2021"),
                 new Project("Task 26, This is a little long", "The status is unknown", "9/10/2021"),
-                new Project("Task 27, This description should be too tion should be to", "Status", "9/20/2021"),
+                new Project("Task 27, This description should be too long to be viewed", "Status", "9/20/2021"),
                 new Project("Task 28, This is a little long", "Status", "10/1/2021"),
                 new Project("Task 29, This desciption is a medium long", "The status is unknown", "10/10/2021"),
                 new Project("Task 30, This desciption is a medium long", "Status", "10/20/2021"),
                 new Project("Task 31, This is a little long", "Status", "11/1/2021"),
                 new Project("Task 33, This desciption is a medium long", "Status", "11/20/2021"),
                 new Project("Task 34, This is a little long", "The status is unknown", "12/1/2021"),
-                new Project("Task 35, This description should be too tion should be to", "Status", "12/10/2021"),
+                new Project("Task 35, This description should be too long to be viewed", "Status", "12/10/2021"),
                 new Project("Task 36, This is a little long", "The status is unknown", "12/20/2021"),
                 new Project("Task 37, This is the", "description that will", "12/31/2021"),
             };
@@ -264,7 +280,7 @@ namespace RoadmapLogic.Tests
 
             var imageStream = RoadmapImage.MakeImage(input, Settings.Default);
             var bytes = imageStream.ToArray();
-            WriteBytesToTimestampedFile("test-longName-twoQaurters", bytes);
+            WriteBytesToTimestampedFile("test-longName-twoQuarters", bytes);
         }
 
         [TestMethod]

--- a/DotNet/RoadmapLogic.Tests/ImageTest.cs
+++ b/DotNet/RoadmapLogic.Tests/ImageTest.cs
@@ -206,7 +206,7 @@ namespace RoadmapLogic.Tests
                 new Project("Task 32", "Status", "11/10/2021"),
                 new Project("Task 33", "Status", "11/20/2021"),
                 new Project("Task 34", "Status", "12/1/2021"),
-                new Project("Task 35", "Status", "12/10/2021"),
+                new Project("Task 35, This description should be too tion should be to", "Status", "12/10/2021"),
                 new Project("Task 36", "Status", "12/20/2021"),
                 new Project("Task 37, This is the", "description that will", "12/31/2021"),
             };
@@ -216,6 +216,55 @@ namespace RoadmapLogic.Tests
             var imageStream = RoadmapImage.MakeImage(input, Settings.Default);            
             var bytes = imageStream.ToArray();
             WriteBytesToTimestampedFile("test-truncated", bytes);
+        }
+
+        [TestMethod]
+        public void CreateAndSaveImageWithProjectNameAndTwoQuarters()
+        {
+            var Projects = new List<Project>
+            {
+                new Project("Task 1, This description should be too tion should be to", "Status", "1/1/2021"),
+                new Project("Task 2, This is a little long", "The status is unknown", "1/10/2021"),
+                new Project("Task 3, This is a little long", "Status", "1/20/2021"),
+                new Project("Task 4, This desciption is a medium long", "The status is unknown", "2/1/2021"),
+                new Project("Task 5, This description should be too tion should be to", "Status", "2/10/2021"),
+                new Project("Task 6, This desciption is a medium long", "Status", "2/20/2021"),
+                new Project("Task 7, This is a little long", "The status is unknown", "3/1/2021"),
+                new Project("Task 8, This description should be too tion should be to", "Status", "3/10/2021"),
+                new Project("Task 9, This desciption is a medium long", "Status", "3/20/2021"),
+                new Project("Task 11, This is a little long, ", "Status", "4/10/2021"),
+                new Project("Task 12, This desciption is a medium long", "The status is unknown", "4/20/2021"),
+                new Project("Task 13, This description should be too tion should be to", "Status", "5/1/2021"),
+                new Project("Task 14, This desciption is a medium long", "The status is unknown", "5/10/2021"),
+                new Project("Task 15, This is a little long", "Status", "5/20/2021"),
+                new Project("Task 16, This desciption is a medium long", "Status", "6/1/2021"),
+                new Project("Task 17, This desciption is a medium long", "The status is unknown", "6/10/2021"),
+                new Project("Task 18, This is a little long", "The status is unknown", "6/20/2021"),
+                new Project("Task 19, This description should be too tion should be to", "Status", "7/1/2021"),
+                new Project("Task 20, This is a little long", "The status is unknown", "7/10/2021"),
+                new Project("Task 21, This description should be too tion should be to", "Status", "7/20/2021"),
+                new Project("Task 22, This desciption is a medium long", "Status", "8/1/2021"),
+                new Project("Task 23, This description should be too tion should be to", "Status", "8/10/2021"),
+                new Project("Task 24, This is a little long", "Status", "8/20/2021"),
+                new Project("Task 25, This desciption is a medium long", "Status", "9/1/2021"),
+                new Project("Task 26, This is a little long", "The status is unknown", "9/10/2021"),
+                new Project("Task 27, This description should be too tion should be to", "Status", "9/20/2021"),
+                new Project("Task 28, This is a little long", "Status", "10/1/2021"),
+                new Project("Task 29, This desciption is a medium long", "The status is unknown", "10/10/2021"),
+                new Project("Task 30, This desciption is a medium long", "Status", "10/20/2021"),
+                new Project("Task 31, This is a little long", "Status", "11/1/2021"),
+                new Project("Task 33, This desciption is a medium long", "Status", "11/20/2021"),
+                new Project("Task 34, This is a little long", "The status is unknown", "12/1/2021"),
+                new Project("Task 35, This description should be too tion should be to", "Status", "12/10/2021"),
+                new Project("Task 36, This is a little long", "The status is unknown", "12/20/2021"),
+                new Project("Task 37, This is the", "description that will", "12/31/2021"),
+            };
+
+            Input input = new Input("Long Name Placard Test:", "01/01/2021", Projects, 2);
+
+            var imageStream = RoadmapImage.MakeImage(input, Settings.Default);
+            var bytes = imageStream.ToArray();
+            WriteBytesToTimestampedFile("test-longName-twoQaurters", bytes);
         }
 
         [TestMethod]

--- a/DotNet/RoadmapLogic/Quarter.cs
+++ b/DotNet/RoadmapLogic/Quarter.cs
@@ -106,18 +106,24 @@ namespace RoadmapLogic
                 chevronXStart += settings.ChevronLength + settings.ChevronGap;
             }
 
-            float xOffset = 210;
+            //float xOffset = 210;
+            RendererOptions renderOptions = new RendererOptions(chevronFont);
+            
             const float yOffset = 464;
 
-            foreach (var quarter in quarters)
+            for (int i = 0; i < quarters.Count(); i++)
             {
+                float xOffset = settings.Margin.Left +
+                    (settings.ChevronGap * i) +
+                    (settings.ChevronLength * i) +
+                    (settings.ChevronLength / 2) +
+                    (settings.ChevronOffset / 2) -
+                    (TextMeasurer.Measure(quarters.ElementAt(i).ToString(), renderOptions).Width / 2);
                 image.Mutate(x => x.DrawText(
-                    quarter.ToString(),
+                    quarters.ElementAt(i).ToString(),
                     chevronFont,
                     Color.White,
                     new PointF(xOffset, yOffset)));
-
-                xOffset += settings.ChevronLength;
             }
         }
 

--- a/DotNet/RoadmapLogic/RoadmapImage.cs
+++ b/DotNet/RoadmapLogic/RoadmapImage.cs
@@ -21,8 +21,15 @@ namespace RoadmapLogic
 
         public static MemoryStream MakeImage(Input input, Settings settings)
         {
+            var quarters = Quarter.GetQuarters(input.StartDate, input.Quarters);
+            // Reduce the font size as number of quarters increase to fit more projects in the image.
+            settings.PlacardFontSize = settings.PlacardFontSize - (quarters.Count - 1);
             var fonts = new Fonts(settings);
-            
+
+            // Increase quarter width as number of quarters decrease
+            settings.ChevronLength = (settings.ImageWidth - settings.Margin.Left - settings.Margin.Right - settings.ChevronOffset - 
+                                        ((quarters.Count - 1) * settings.ChevronGap)) / quarters.Count;
+
             if (input.IsValid)
             {
                 var teamText = string.IsNullOrWhiteSpace(input.Team) ? "[No team supplied]" : input.Team;
@@ -43,8 +50,6 @@ namespace RoadmapLogic
                         fonts.TeamFont,
                         Color.Black,
                         new PointF(settings.Margin.Right, settings.MidPoint - settings.PlotHeight - settings.TeamFontSize - 10));
-
-                    var quarters = Quarter.GetQuarters(input.StartDate, input.Quarters);
 
                     DrawLegsAndPlacards(input, settings, fonts, image, quarters);
 

--- a/DotNet/RoadmapLogic/Settings.cs
+++ b/DotNet/RoadmapLogic/Settings.cs
@@ -64,7 +64,6 @@ namespace RoadmapLogic
             ChevronHeight = chevronHeight;
             ChevronOffset = chevronOffset;
             ChevronGap = chevronGap;
-            ChevronLength = ((ImageWidth - Margin.Left - Margin.Right - ChevronOffset) - (3 * ChevronGap)) / 4F;
             DogLegWidth = dogLegWidth;
             TeamFontSize = teamFontSize;
             PlotHeight = ImageHeight - Margin.Bottom - MidPoint - (ChevronHeight / 2);
@@ -79,8 +78,8 @@ namespace RoadmapLogic
             CopmanyLogo = !string.IsNullOrWhiteSpace(companyLogo) ? companyLogo : s_CompanyLogo;
         }
 
-        public static Settings Default => new Settings(1486, 839, new Margin(103, 70), 485, 50, 25, 4, 30, 32,
-            new int[] { 217, 141, 65 }, new int[] { 176, 100, 24 }, 10, 20, 16, 36,
+        public static Settings Default => new Settings(1486, 839, new Margin(20, 70), 485, 50, 25, 4, 30, 32,
+            new int[] { 217, 141, 65 }, new int[] { 176, 100, 24 }, 10, 20, 12, 36,
             "Product delivery roadmap", 57, 100, DefaultColors.QuantumBlue,
             s_SegoeUiNormalBase64, s_SegoeUiBoldBase64, s_CompanyLogo);
 
@@ -125,6 +124,7 @@ namespace RoadmapLogic
         public float ChevronLength
         {
             get;
+            internal set;
         }
 
         public float DogLegWidth
@@ -170,6 +170,7 @@ namespace RoadmapLogic
         public int PlacardFontSize
         {
             get;
+            internal set;
         }
 
         public int QuarterFontSize

--- a/DotNet/RoadmapLogic/Settings.cs
+++ b/DotNet/RoadmapLogic/Settings.cs
@@ -79,7 +79,7 @@ namespace RoadmapLogic
         }
 
         public static Settings Default => new Settings(1486, 839, new Margin(20, 70), 485, 50, 25, 4, 30, 32,
-            new int[] { 217, 141, 65 }, new int[] { 176, 100, 24 }, 10, 20, 12, 36,
+            new int[] { 217, 141, 65 }, new int[] { 176, 100, 24 }, 10, 20, 16, 36,
             "Product delivery roadmap", 57, 100, DefaultColors.QuantumBlue,
             s_SegoeUiNormalBase64, s_SegoeUiBoldBase64, s_CompanyLogo);
 


### PR DESCRIPTION
Hi @peterchafe, I tried different options and as you had said we cannot meet every possible scenario. I did combined approach by considering both quarter width and font size to try to find balance where most of the scenario will be covered. Here are changes that I made:

Changed default left/right margin and placard font size
Increased quarter width as number of quarters decreased.
Reduced the font size as number of quarters increased to fit more projects in the image.
Please feel free to adjust default margin and font size as well any other changes code as you deem appropriate to cover most scenarios. Thanks