### PR TITLE
Upgrade lambda to .NET 6

### DIFF
--- a/DotNet/Roadmap.sln
+++ b/DotNet/Roadmap.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30717.126
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.33205.214
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RoadmapLogic", "RoadmapLogic\RoadmapLogic.csproj", "{2563E37E-D357-4F3A-8303-9EEA2CA8A33A}"
 EndProject
@@ -9,7 +9,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RoadmapLogic.Tests", "Roadm
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RoadmapLambda", "RoadmapLambda\RoadmapLambda.csproj", "{56AD93B1-AA7F-4708-93BC-9CC76900B458}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RoadmapApp", "RoadmapApp\RoadmapApp.csproj", "{72110A50-B616-43DF-B51B-92E3D021CDCD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RoadmapApp", "RoadmapApp\RoadmapApp.csproj", "{72110A50-B616-43DF-B51B-92E3D021CDCD}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/DotNet/RoadmapApp/Program.cs
+++ b/DotNet/RoadmapApp/Program.cs
@@ -54,7 +54,7 @@ namespace RoadmapApp
 
             if (File.Exists(outputFile))
             {
-                Process process = new Process();
+                Process process = new();
                 process.StartInfo.FileName = "explorer";
                 process.StartInfo.Arguments = outputFile;
                 process.StartInfo.RedirectStandardOutput = false;

--- a/DotNet/RoadmapApp/RoadmapApp.csproj
+++ b/DotNet/RoadmapApp/RoadmapApp.csproj
@@ -2,12 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\RoadmapLogic\RoadmapLogic.csproj" />

--- a/DotNet/RoadmapLambda/Function.cs
+++ b/DotNet/RoadmapLambda/Function.cs
@@ -8,11 +8,11 @@ namespace RoadmapLambda
 {
     public class Function
     {
-        public string FunctionHandler(FunctionInput input, ILambdaContext context)
+        public static string FunctionHandler(FunctionInput input, ILambdaContext context)
         {
             var image = RoadmapImage.MakeImage(input.ToRoadmapInput(), Settings.Default);
 
-            return new Base64Converter().ToBase64(image);
+            return Base64Converter.ToBase64(image);
         }
     }
 }

--- a/DotNet/RoadmapLambda/FunctionInput.cs
+++ b/DotNet/RoadmapLambda/FunctionInput.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 
 namespace RoadmapLambda
 {

--- a/DotNet/RoadmapLambda/Properties/launchSettings.json
+++ b/DotNet/RoadmapLambda/Properties/launchSettings.json
@@ -3,8 +3,8 @@
     "Mock Lambda Test Tool": {
       "commandName": "Executable",
       "commandLineArgs": "--port 5050",
-      "workingDirectory": ".\\bin\\$(Configuration)\\netcoreapp3.1",
-      "executablePath": "C:\\Users\\%USERNAME%\\.dotnet\\tools\\dotnet-lambda-test-tool-3.1.exe"
+      "workingDirectory": ".\\bin\\$(Configuration)\\net6.0",
+      "executablePath": "%USERPROFILE%\\.dotnet\\tools\\dotnet-lambda-test-tool-6.0.exe"
     }
   }
 }

--- a/DotNet/RoadmapLambda/RoadmapLambda.csproj
+++ b/DotNet/RoadmapLambda/RoadmapLambda.csproj
@@ -1,12 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <AWSProjectType>Lambda</AWSProjectType>
+	<TargetFramework>net6.0</TargetFramework>
+	<ImplicitUsings>enable</ImplicitUsings>
+	<GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+	<AWSProjectType>Lambda</AWSProjectType>
+	<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+	<PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="2.0.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.1.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\RoadmapLogic\RoadmapLogic.csproj" />

--- a/DotNet/RoadmapLambda/aws-lambda-tools-defaults.json
+++ b/DotNet/RoadmapLambda/aws-lambda-tools-defaults.json
@@ -1,21 +1,16 @@
-
 {
-    "Information" : [
-        "This file provides default values for the deployment wizard inside Visual Studio and the AWS Lambda commands added to the .NET Core CLI.",
-        "To learn more about the Lambda commands with the .NET Core CLI execute the following command at the command line in the project root directory.",
-        "dotnet lambda help",
-        "All the command line options for the Lambda command can be specified in this file."
-    ],
-    "profile"     : "default",
-    "region"      : "us-east-2",
-    "configuration" : "Debug",
-    "framework"     : "netcoreapp3.1",
-    "function-runtime" : "dotnetcore3.1",
-    "function-memory-size" : 1024,
-    "function-timeout"     : 30,
-    "function-handler"     : "RoadmapLambda::RoadmapLambda.Function::FunctionHandler",
-    "function-name"        : "rdamt-roadmap-generator-test",
-    "function-role"        : "arn:aws:iam::040896679115:role/service-role/rdamt-roadmap-generator-test-role-a6hhvcr0",
-    "tracing-mode"         : "PassThrough",
-    "environment-variables" : ""
+  "Information": [
+    "This file provides default values for the deployment wizard inside Visual Studio and the AWS Lambda commands added to the .NET Core CLI.",
+    "To learn more about the Lambda commands with the .NET Core CLI execute the following command at the command line in the project root directory.",
+    "dotnet lambda help",
+    "All the command line options for the Lambda command can be specified in this file."
+  ],
+  "profile": "default",
+  "region": "us-east-2",
+  "configuration": "Release",
+  "function-architecture": "x86_64",
+  "function-runtime": "dotnet6",
+  "function-memory-size": 256,
+  "function-timeout": 30,
+  "function-handler": "RoadmapLambda::RoadmapLambda.Function::FunctionHandler"
 }

--- a/DotNet/RoadmapLogic.Tests/DateConverterTest.cs
+++ b/DotNet/RoadmapLogic.Tests/DateConverterTest.cs
@@ -42,12 +42,12 @@ namespace RoadmapLogic.Tests
             proceed = DateConverter.ConvertToDate("Sep 5, 2021", out date);
 
             Assert.AreEqual(false, proceed);
-            Assert.AreNotEqual("09/05/2021", date);
+            Assert.AreNotEqual(new DateTime(2021, 9, 5), date);
 
             proceed = DateConverter.ConvertToDate("Mca 4, 021", out date);
 
             Assert.AreEqual(false, proceed);
-            Assert.AreNotEqual("09/05/2021", date);
+            Assert.AreNotEqual(new DateTime(2021, 9, 5), date);
         }
     }
 }

--- a/DotNet/RoadmapLogic.Tests/ImageTest.cs
+++ b/DotNet/RoadmapLogic.Tests/ImageTest.cs
@@ -339,7 +339,7 @@ namespace RoadmapLogic.Tests
 
             var saveTo = Path.Combine(pathUpToFilename, txtFile);
 
-            File.WriteAllText(saveTo, new Base64Converter().ToBase64(imageFile));
+            File.WriteAllText(saveTo, Base64Converter.ToBase64(imageFile));
         }
 
         [TestMethod]

--- a/DotNet/RoadmapLogic.Tests/RoadmapLogic.Tests.csproj
+++ b/DotNet/RoadmapLogic.Tests/RoadmapLogic.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -14,14 +14,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.5" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-	<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DotNet/RoadmapLogic/Base64Converter.cs
+++ b/DotNet/RoadmapLogic/Base64Converter.cs
@@ -3,21 +3,21 @@ using System.IO;
 
 namespace RoadmapLogic
 {
-    public class Base64Converter
+    public static class Base64Converter
     {
-        public string ToBase64(MemoryStream memoryStream)
+        public static string ToBase64(MemoryStream memoryStream)
         {
             var bytes = memoryStream.ToArray();
             return ToBase64Helper(bytes);
         }
 
-        public string ToBase64(string filePath)
+        public static string ToBase64(string filePath)
         {
             var bytes = File.ReadAllBytes(filePath);
             return ToBase64Helper(bytes);
         }
 
-        private string ToBase64Helper(byte[] bytes)
+        private static string ToBase64Helper(byte[] bytes)
         {
             return Convert.ToBase64String(bytes);
         }

--- a/DotNet/RoadmapLogic/RoadmapLogic.csproj
+++ b/DotNet/RoadmapLogic/RoadmapLogic.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta0013" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.3" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta11" />


### PR DESCRIPTION
I updated the AWS Lambda runtime to .NET 6 since .NET Core 3.1 is approaching end of life. Manually deployed the new code and it works.